### PR TITLE
Fix for wrong chdir by adding needed path separator

### DIFF
--- a/source/universal_importer/import.rb
+++ b/source/universal_importer/import.rb
@@ -97,7 +97,7 @@ module UniversalImporter
       return unless @source_file_path.is_a?(String)
 
       # Directory of the source model. It's an absolute path.
-      @source_dir = File.dirname(@source_file_path)
+      @source_dir = File.dirname(@source_file_path) + File::SEPARATOR
 
       # A temporary directory where the textures, embedded in the source model, are extracted.
       # It's an absolute path and a subfolder ("uir-textures") of the directory of the source model.


### PR DESCRIPTION
Because source_dir doesn't end in / when importing a file from D:\ (on Windows), later in assimp.rb 'cd /d "D:"' is being done (should be 'cd /d "D:/"'), which results in just keeping the current directory on D: because it has no path, just a drive letter, which results in the current directory of the drive not being changed (stays something like /Users/username/Documents for instance), and not the root / as expected. The File.join statements are smart enough to properly join their first arguments ending on File::SEPARATOR with their second arguments.